### PR TITLE
Fix double click reset

### DIFF
--- a/audio-mixer.html
+++ b/audio-mixer.html
@@ -358,6 +358,13 @@
 
         // Mouse event handlers
         function handleFaderMouseDown(e) {
+            // Use click detail to detect double clicks since re-rendering
+            // replaces the fader element between clicks
+            if (e.detail === 2) {
+                handleFaderDoubleClick(e);
+                return;
+            }
+
             dragStartTime = Date.now();
             isDragging = true;
             hasDragged = false;
@@ -781,7 +788,6 @@
             const mainFader = document.getElementById('main-fader');
             if (mainFader) {
                 mainFader.addEventListener('mousedown', handleFaderMouseDown);
-                mainFader.addEventListener('dblclick', handleFaderDoubleClick);
             }
 
             // Add event listeners for effect faders


### PR DESCRIPTION
## Summary
- support double click detection inside the mousedown handler
- remove dblclick event listener

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c21321e48325b8d67eb75873925e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of double-click detection on the main fader control, ensuring consistent behavior even after interface updates or re-renders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->