### PR TITLE
Fix double click reset

### DIFF
--- a/audio-mixer.html
+++ b/audio-mixer.html
@@ -358,11 +358,17 @@
 
         // Mouse event handlers
         function handleFaderMouseDown(e) {
+            // Use click detail to detect double clicks since re-rendering
+            // replaces the fader element between clicks
+            if (e.detail === 2) {
+                handleFaderDoubleClick(e);
+                return;
+            }
+
             dragStartTime = Date.now();
             isDragging = true;
             hasDragged = false;
             initialMouseY = e.clientY;
-            handleFaderMouseMove(e);
         }
 
         function handleFaderDoubleClick(e) {
@@ -781,7 +787,6 @@
             const mainFader = document.getElementById('main-fader');
             if (mainFader) {
                 mainFader.addEventListener('mousedown', handleFaderMouseDown);
-                mainFader.addEventListener('dblclick', handleFaderDoubleClick);
             }
 
             // Add event listeners for effect faders


### PR DESCRIPTION
## Summary
- support double click detection inside the mousedown handler
- remove dblclick event listener
- avoid moving the fader on initial click

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6885c21321e48325b8d67eb75873925e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved double-click detection on the main fader for smoother interaction by consolidating event handling.
* **Bug Fixes**
  * Resolved potential conflicts between double-click and drag actions on the main fader.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->