### PR TITLE
Reverse trackpad scroll direction

### DIFF
--- a/audio-mixer.html
+++ b/audio-mixer.html
@@ -470,7 +470,7 @@ function toggleEffectsView() {
             e.preventDefault();
             const selectedTrack = getSelectedTrack();
             if (!selectedTrack) return;
-            const delta = -e.deltaY / 100; // positive when scrolling up
+            const delta = e.deltaY / 100; // positive when scrolling down
             const newVolume = Math.max(-60, Math.min(6, selectedTrack.volume + delta * 2));
             state.tracks = state.tracks.map(track =>
                 track.id === selectedTrack.id


### PR DESCRIPTION
## Summary
- reverse the trackpad scroll wheel handling on the main fader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885d58546e88325afefe77821928f9a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reversed the direction of volume adjustment when using the mouse wheel on the main fader. Scrolling down now increases the volume, and scrolling up decreases it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->